### PR TITLE
Override learn logging test prefix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lighthouse"
 uuid = "ac2c24cd-07f0-4848-96b2-1b82c3ea0e59"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/learn.jl
+++ b/test/learn.jl
@@ -193,8 +193,9 @@ end
 
         # And now, `optimal_threshold_class` during learning
         Lighthouse.learn!(model, logger, () -> train_batches, () -> test_batches, votes;
-                          epoch_limit=limit, optimal_threshold_class=2)
-        plot_data = last(logger.logged["test_set_evaluation/metrics_per_epoch"])
+                          epoch_limit=limit, optimal_threshold_class=2,
+                          test_set_logger_prefix="validation_set")
+        plot_data = last(logger.logged["validation_set_evaluation/metrics_per_epoch"])
         @test haskey(plot_data, "optimal_threshold")
         @test haskey(plot_data, "optimal_threshold_class")
         @test plot_data["optimal_threshold_class"] == 2


### PR DESCRIPTION
Allow users to override default test set logging prefix during model training.