### PR TITLE
Add `binary_comparison_metrics_plot` with ROC curves

### DIFF
--- a/docs/src/plotting.md
+++ b/docs/src/plotting.md
@@ -301,5 +301,7 @@ data2["per_class_roc_aucs"] = stable_rand(5)
 data2["per_class_reliability_calibration_curves"] = curves
 data2["per_class_reliability_calibration_scores"] = stable_rand(5)
 
+data["optimal_threshold_class"] = data2["optimal_threshold_class"] = 1
+
 binary_comparison_metrics_plot([(; name="Model1", data), (; name="Model2", data=data2)])
 ```

--- a/docs/src/plotting.md
+++ b/docs/src/plotting.md
@@ -274,3 +274,32 @@ data["optimal_threshold"] = nothing
 
 evaluation_metrics_plot(data)
 ```
+
+# Binary comparison metrics plot
+
+```@docs
+Lighthouse.binary_comparison_metrics_plot
+```
+
+```@example 1
+using Lighthouse: binary_comparison_metrics_plot
+curves = [(LinRange(0, 1, 10), range(0, stop=i/2, length=10) .+ (stable_randn(10) .* 0.1)) for i in -1:3]
+
+data2 = Dict{String, Any}()
+data2["confusion_matrix"] = stable_rand(5, 5)
+data2["class_labels"] = classes
+
+data2["per_class_kappas"] = stable_rand(5)
+data2["multiclass_kappa"] = stable_rand()
+data2["per_class_IRA_kappas"] = stable_rand(5)
+data2["multiclass_IRA_kappas"] = stable_rand()
+
+data2["per_class_pr_curves"] = curves
+data2["per_class_roc_curves"] = curves
+data2["per_class_roc_aucs"] = stable_rand(5)
+
+data2["per_class_reliability_calibration_curves"] = curves
+data2["per_class_reliability_calibration_scores"] = stable_rand(5)
+
+binary_comparison_metrics_plot([(; name="Model1", data), (; name="Model2", data=data2)])
+```

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -499,13 +499,13 @@ function extract_common_entries(results, common_keys)
 end
 
 """
-    binary_comparison_metrics_plot(results; resolution=(1000, 1000), textsize=12, primary_class=1)
+    binary_comparison_metrics_plot(results; resolution=(1000, 1000), textsize=12)
 
 Generates a comparison plot between all the models in `results`. Assumes each element
 of results represents the metrics for a particular model and has a `name` and a `data` field,
 where `data` is the result of [`evaluation_metrics_plot`](@ref).
 """
-function binary_comparison_metrics_plot(results; resolution=(1000, 1000), textsize=12, primary_class=1)
+function binary_comparison_metrics_plot(results; resolution=(1000, 1000), textsize=12)
     common_entries = extract_common_entries(results, ("class_labels", "optimal_threshold_class"))
     n_classes = length(common_entries["class_labels"])
     optimal_threshold_class = common_entries["optimal_threshold_class"]
@@ -524,9 +524,8 @@ function binary_comparison_metrics_plot(results; resolution=(1000, 1000), textsi
         push!(labels, string(name, " ", class))
         push!(curves, data["per_class_roc_curves"][optimal_threshold_class])
         push!(aucs, data["per_class_roc_aucs"][optimal_threshold_class])
-        data["class_labels"]; legend=nothing)
     end
-    ax = plot_roc_curves!(fig[1, 1], curves, aucs, labels)
+    ax = plot_roc_curves!(fig[1, 1], identity.(curves), identity.(aucs), labels)
 
     return fig
 end

--- a/test/comparisons.jl
+++ b/test/comparisons.jl
@@ -4,18 +4,26 @@
         (; name="model1", data=Dict("class_labels" => ["hi", "bye"], "unrelated"=>1)),
         (; name="model2", data=Dict("class_labels" => ["hi", "bye"], "unrelated"=>2))
     ]
-    @test extract_common_entries(consistent_results, common_keys) == Dict("class_labels" => ["hi", "bye"])
+    @test Lighthouse.extract_common_entries(consistent_results, common_keys) == Dict("class_labels" => ["hi", "bye"])
 
     inconsistent_results = [
         (; name="model1", data=Dict("class_labels" => ["hi", "bye"], "unrelated"=>1)),
         (; name="model2", data=Dict("class_labels" => ["hi", "goodbye"], "unrelated"=>2))
     ]
-    @test_throws ArgumentError extract_common_entries(inconsistent_results, common_keys)
+    @test_throws ArgumentError Lighthouse.extract_common_entries(inconsistent_results, common_keys)
 end
 
 @testset "binary_comparison_metrics_plot" begin
-    m1 = (; name = "Model1", data = Dict("class_labels" => ["a", "b"],
-                                         "optimal_threshold_class" => 1,
-                                         ""))
+    results_1 = train_binary_model(mktempdir(); rng = StableRNG(1))
+    plot_data_1 = last(results_1.logger.logged["test_set_evaluation/metrics_per_epoch"])
+    plot_data_1["optimal_threshold_class"] = 1
+    m1 = (; name = "Model1", data = plot_data_1)
 
+    results_2 = train_binary_model(mktempdir(); rng = StableRNG(2))
+    plot_data_2 = last(results_2.logger.logged["test_set_evaluation/metrics_per_epoch"])
+    plot_data_2["optimal_threshold_class"] = 1
+    m2 = (; name = "Model2", data = plot_data_2)
+
+    binary_comparison_metrics = Lighthouse.binary_comparison_metrics_plot((m1, m2))
+    @testplot binary_comparison_metrics
 end

--- a/test/comparisons.jl
+++ b/test/comparisons.jl
@@ -1,0 +1,21 @@
+@testset "extract_common_entries" begin
+    common_keys = ("class_labels",)
+    consistent_results = [
+        (; name="model1", data=Dict("class_labels" => ["hi", "bye"], "unrelated"=>1)),
+        (; name="model2", data=Dict("class_labels" => ["hi", "bye"], "unrelated"=>2))
+    ]
+    @test extract_common_entries(consistent_results, common_keys) == Dict("class_labels" => ["hi", "bye"])
+
+    inconsistent_results = [
+        (; name="model1", data=Dict("class_labels" => ["hi", "bye"], "unrelated"=>1)),
+        (; name="model2", data=Dict("class_labels" => ["hi", "goodbye"], "unrelated"=>2))
+    ]
+    @test_throws ArgumentError extract_common_entries(inconsistent_results, common_keys)
+end
+
+@testset "binary_comparison_metrics_plot" begin
+    m1 = (; name = "Model1", data = Dict("class_labels" => ["a", "b"],
+                                         "optimal_threshold_class" => 1,
+                                         ""))
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,9 +25,9 @@ macro testplot(fig_name)
     end
 end
 
-include("comparisons.jl")
 include("plotting.jl")
 include("metrics.jl")
 include("learn.jl")
+include("comparisons.jl")
 include("utilities.jl")
 include("logger.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ macro testplot(fig_name)
     end
 end
 
+include("comparisons.jl")
 include("plotting.jl")
 include("metrics.jl")
 include("learn.jl")


### PR DESCRIPTION
This starts on #41 but only does ROC curves. My thought is maybe we could add more plots in PRs over time, unless someone had dedicated time to do it all soon.