### PR TITLE
refactor `evaluation_metrics_plot` methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lighthouse"
 uuid = "ac2c24cd-07f0-4848-96b2-1b82c3ea0e59"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.13.1"
+version = "0.13.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,6 +38,7 @@ accuracy
 binary_statistics
 cohens_kappa
 calibration_curve
+Lighthouse.evaluation_metrics
 ```
 
 ## Utilities

--- a/test/learn.jl
+++ b/test/learn.jl
@@ -101,10 +101,16 @@ end
         # Test startified eval
         strata = [Set("group $(j % Int(ceil(sqrt(j))))" for j in 1:(i - 1))
                   for i in 1:size(votes, 1)]
-        plot, plot_data = evaluation_metrics_plot(predicted_hard, predicted_soft,
-                                                  elected_hard, model.classes, 0.0:0.01:1.0;
-                                                  votes=votes, strata=strata)
+        plot_data = evaluation_metrics(predicted_hard, predicted_soft,
+                                        elected_hard, model.classes, 0.0:0.01:1.0;
+                                        votes=votes, strata=strata)
         @test haskey(plot_data, "stratified_kappas")
+        plot = evaluation_metrics_plot(plot_data)
+
+        plot2, plot_data2 = @test_deprecated evaluation_metrics_plot(predicted_hard, predicted_soft,
+                                                                     elected_hard, model.classes, 0.0:0.01:1.0;
+                                                                     votes=votes, strata=strata)
+        @test isequal(plot_data, plot_data2) # check these are the same
 
         # Test plotting
         plot_data = last(logger.logged["test_set_evaluation/metrics_per_epoch"])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using StableRNGs
 using Lighthouse
 using Lighthouse: plot_reliability_calibration_curves, plot_pr_curves,
                   plot_roc_curves, plot_kappas, plot_confusion_matrix,
-                  evaluation_metrics_plot
+                  evaluation_metrics_plot, evaluation_metrics
 using Base.Threads
 using CairoMakie
 


### PR DESCRIPTION
Currently, `evaluation_metrics_plot` takes either a `Dict` of `plot_data`, or the ingredients necessary to build this dict. In the first case, it returns only a figure; in the second case, it returns the dictionary along with a figure.

This PR refactors thing so that `evaluation_metrics` builds the `Dict` (without doing any plotting), and `evaluation_metrics_plot` plots it. The old method which both built the dict and plotted it is deprecated in this PR.

This should be entirely non-breaking, but allow downstream users to access the plotting dict without needing to plot, and streamline things to be a bit more coherent (in my opinion).