### PR TITLE
Add F1 score to `binary_statistics`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lighthouse"
 uuid = "ac2c24cd-07f0-4848-96b2-1b82c3ea0e59"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.14.3"
+version = "0.14.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -55,6 +55,7 @@ with the following fields for the given `class_index`:
 - `false_positive_rate`
 - `false_negative_rate`
 - `precision`
+- `f1`
 """
 function binary_statistics(confusion::AbstractMatrix, class_index::Integer)
     total = sum(confusion)
@@ -80,10 +81,11 @@ function binary_statistics(confusion::AbstractMatrix, class_index::Integer)
                           (false_negatives / actual_positives)
     precision = (true_positives == 0 && predicted_positives == 0) ? NaN :
                 (true_positives / predicted_positives)
+    f1 = (2 * precision * true_positive_rate) / (precision + true_positive_rate)
     return (; predicted_positives, predicted_negatives, actual_positives, actual_negatives,
             true_positives, true_negatives, false_positives, false_negatives,
             true_positive_rate, true_negative_rate, false_positive_rate,
-            false_negative_rate, precision)
+            false_negative_rate, precision, f1)
 end
 
 function binary_statistics(confusion::AbstractMatrix)

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -23,6 +23,7 @@
     @test stats.false_positive_rate == 1 / 6
     @test stats.false_negative_rate == 0.5
     @test stats.precision == 0.5
+    @test stats.f1 == 0.5
 
     labels = rand(StableRNG(42), 1:3, 100)
     hard_label_pairs = zip(labels, labels)
@@ -39,6 +40,7 @@
         @test stats.true_positive_rate == stats.true_negative_rate == 1
         @test stats.false_positive_rate == stats.false_negative_rate == 0
         @test stats.precision == 1
+        @test stats.f1 == 1
     end
 
     n, k = 1_000_000, 2
@@ -63,6 +65,7 @@
     @test isapprox(stats.false_positive_rate, 0.5; atol=0.02)
     @test isapprox(stats.false_negative_rate, 0.5; atol=0.02)
     @test isapprox(stats.precision, 0.5; atol=0.02)
+    @test isapprox(stats.f1, 0.5; atol=0.02)
 
     @test confusion_matrix(10, ()) == zeros(10, 10)
     @test all(isnan, cohens_kappa(10, ()))
@@ -81,6 +84,7 @@
     @test stats.false_positive_rate == 0
     @test stats.false_negative_rate == 0
     @test isnan(stats.precision)
+    @test isnan(stats.f1)
 
     for p in 0:0.1:1
         @test Lighthouse._cohens_kappa(p, p) == 0


### PR DESCRIPTION
F1 score is another common metric that is often used for evaluating model performance, so this PR adds it to the `binary_statistics` function.