### PR TITLE
add log_line_series for lwb

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lighthouse"
 uuid = "ac2c24cd-07f0-4848-96b2-1b82c3ea0e59"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.14.4"
+version = "0.14.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/learn.jl
+++ b/src/learn.jl
@@ -45,6 +45,12 @@ function log_value!(logger::LearnLogger, field::AbstractString, value)
     return value
 end
 
+
+function log_line_series!(logger::LearnLogger, field::AbstractString, series, series_labels)
+    @warn "`log_line_series!` not implemented for `LearnLogger`"
+    return nothing
+end
+
 """
     log_evaluation_row!(logger, field::AbstractString, metrics)
 

--- a/test/logger.jl
+++ b/test/logger.jl
@@ -27,5 +27,8 @@
 end
 
 @testset "`Generic datastructure logging`" begin
-    @test isnothing(Lighthosue.log_line_series!(logger, "foo", 3, 2), nothing)
+    mktempdir() do logdir
+        logger = LearnLogger(logdir, "test_run")
+        @test isnothing(Lighthouse.log_line_series!(logger, "foo", 3, 2))
+    end
 end

--- a/test/logger.jl
+++ b/test/logger.jl
@@ -25,3 +25,7 @@
         end
     end
 end
+
+@testset "`Generic datastructure logging`" begin
+    @test isnothing(Lighthosue.log_line_series!(logger, "foo", 3, 2), nothing)
+end


### PR DESCRIPTION
Per @ericphanson's remarks:

> I think it doesn't fit with what log_plot currently does in lighthouse, which is dump a big dictionary of data associated to a plot, along with a png.. I think wandb needs something more structured. So I think we should add new “lighthouse logging interface” surface - new functions- and then implement them in lighthousewandb. Maybe tensorboard should just ignore them (no-op fallback)

Adding the first structured function, to log a line series