### PR TITLE
[docs] add note about `Base.flush` to logging interface

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,6 +38,8 @@ log_plot!
 step_logger!
 ```
 
+in addition to `Base.flush(logger)` (which can be a no-op by defining `Base.flush(::MyLoggingType) = nothing`).
+
 These primitives can be used in implementations of [`train!`](@ref), [`evaluate!`](@ref), and [`predict!`](@ref), as well as in the following composite logging functions, which by default call the above primitives. Loggers may provide custom implementations of these.
 
 ```@docs


### PR DESCRIPTION
This is currently required (called in `learn!`) although it does nothing on any logger I know of. I think we should remove it at some point, but for now we should at least document that it is required.