### PR TITLE
Fix plotting of `EvaluationRow` when multiclass and no votes

### DIFF
--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -332,7 +332,8 @@ function evaluation_metrics_plot(row::EvaluationRow; resolution=(1000, 1000),
     kappa_data = multiclass ? vcat(row.multiclass_kappa, row.per_class_kappas) :
                  row.per_class_kappas
 
-    if issubset([:multiclass_IRA_kappas, :per_class_IRA_kappas], keys(row))
+    if issubset([:multiclass_IRA_kappas, :per_class_IRA_kappas], keys(row)) &&
+       all(has_value.([row.multiclass_IRA_kappas, row.per_class_IRA_kappas]))
         IRA_kappa_data = multiclass ?
                          vcat(row.multiclass_IRA_kappas, row.per_class_IRA_kappas) :
                          row.per_class_IRA_kappas

--- a/test/learn.jl
+++ b/test/learn.jl
@@ -99,6 +99,13 @@ end
         @test length(logger.logged["wheeeeeee/time_in_seconds_for_all_time"]) == 1
         @test length(logger.logged["wheeeeeee/metrics_for_all_time"]) == 1
 
+        # Test plotting with no votes directly with eval row
+        eval_row = Lighthouse.evaluation_metrics_row(predicted_hard, predicted_soft,
+                                                     elected_hard, model.classes;
+                                                     votes=nothing)
+        all_together_no_ira = evaluation_metrics_plot(eval_row)
+        @testplot all_together_no_ira
+
         # Round-trip `onehot` for codecov
         onehot_hard = map(h -> vec(Lighthouse.onehot(model, h)), predicted_hard)
         @test map(h -> findfirst(h), onehot_hard) == predicted_hard


### PR DESCRIPTION
This attempts to fix the case when `evalution_metrics_plot` fails when passed in the result of `evaluation_row_metrics` for a multi-class, single-rater problem.

closes #75 