### PR TITLE
Update F1 score implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lighthouse"
 uuid = "ac2c24cd-07f0-4848-96b2-1b82c3ea0e59"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.14.11"
+version = "0.14.12"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -87,7 +87,7 @@ function binary_statistics(confusion::AbstractMatrix, class_index::Integer)
                           (false_negatives / actual_positives)
     precision = (true_positives == 0 && predicted_positives == 0) ? NaN :
                 (true_positives / predicted_positives)
-    f1 = (2 * precision * true_positive_rate) / (precision + true_positive_rate)
+    f1 = true_positives / (true_positives + 0.5 * (false_positives + false_negatives))
     return (; predicted_positives, predicted_negatives, actual_positives, actual_negatives,
             true_positives, true_negatives, false_positives, false_negatives,
             true_positive_rate, true_negative_rate, false_positive_rate,

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -86,6 +86,33 @@
     @test isnan(stats.precision)
     @test isnan(stats.f1)
 
+    c = [0 0
+         0 8]
+    stats = binary_statistics(c, 1)
+    @test stats.true_positives == 0
+    @test stats.true_negatives == 8
+    @test stats.false_positives == 0
+    @test stats.false_negatives == 0
+    @test isnan(stats.f1)
+
+    c = [0 2
+         0 6]
+    stats = binary_statistics(c, 1)
+    @test stats.true_positives == 0
+    @test stats.true_negatives == 6
+    @test stats.false_positives == 2
+    @test stats.false_negatives == 0
+    @test stats.f1 == 0
+
+    c = [0 0
+         2 6]
+    stats = binary_statistics(c, 1)
+    @test stats.true_positives == 0
+    @test stats.true_negatives == 6
+    @test stats.false_positives == 0
+    @test stats.false_negatives == 2
+    @test stats.f1 == 0
+
     for p in 0:0.1:1
         @test Lighthouse._cohens_kappa(p, p) == 0
         if p > 0


### PR DESCRIPTION
This updates the implementation of the F1 score such that is avoids outputting `NaN` when there are no predicted positives (as long as false negatives are present) or no actual positives (as long as false positives are present). It still may output `NaN` if only true-negative exist.