### PR TITLE
Only upload images to Percy from latest Julia version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
       - name: Percy Upload
         uses: percy/exec-action@v0.3.1
+        if: matrix.version == 1
         with:
           custom-command: "npx @percy/cli upload ./test/plot_results"
         env:


### PR DESCRIPTION
...by only uploading results from Julia v1.

- [x] Merge block: confirm percy upload actually happens!