### PR TITLE
Allow missing expert curves in discrimination calibration curve plot

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lighthouse"
 uuid = "ac2c24cd-07f0-4848-96b2-1b82c3ea0e59"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.14.15"
+version = "0.14.16"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -163,8 +163,7 @@ function plot_binary_discrimination_calibration_curves!(subfig::FigurePosition,
                   ylabel="Predicted positive probability")
     else
         per_expert = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :PerExpert;
-                               solid_color=:darkgrey,
-                               color=nothing)
+                               solid_color=:darkgrey, color=nothing)
         set_from_kw!(per_expert, :linewidth, kw, 2)
         ax = series_plot!(subfig, per_expert_calibration_curves, nothing; legend=nothing,
                           title="Detection calibration", xlabel="Expert agreement rate",

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -142,7 +142,7 @@ end
 
 function plot_binary_discrimination_calibration_curves!(subfig::FigurePosition,
                                                         calibration_curve::SeriesCurves, calibration_score,
-                                                        per_expert_calibration_curves::SeriesCurves,
+                                                        per_expert_calibration_curves::Union{SeriesCurves,Missing},
                                                         per_expert_calibration_scores, optimal_threshold,
                                                         discrimination_class::AbstractString; kw...)
     kw = values(kw)
@@ -154,12 +154,14 @@ function plot_binary_discrimination_calibration_curves!(subfig::FigurePosition,
     set_from_kw!(scatter_theme, :makersize, kw, 5)
     set_from_kw!(scatter_theme, :marker, kw, :rect)
 
-    per_expert = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :PerExpert; solid_color=:darkgrey,
-                           color=nothing)
-    set_from_kw!(per_expert, :linewidth, kw, 2)
-    ax = series_plot!(subfig, per_expert_calibration_curves, nothing; legend=nothing,
-                      title="Detection calibration", xlabel="Expert agreement rate",
-                      ylabel="Predicted positive probability", scatter=scatter_theme, per_expert...)
+    if ismissing(per_expert_calibration_curves)
+        ax = Axis(subfig)
+    else
+        per_expert = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :PerExpert; solid_color=:darkgrey,
+                            color=nothing)
+        set_from_kw!(per_expert, :linewidth, kw, 2)
+        ax = series_plot!(subfig, per_expert_calibration_curves, nothing;  scatter=scatter_theme, per_expert...)
+    end
 
     calibration = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :CalibrationCurve;
                             solid_color=:navyblue, markerstrokewidth=0)
@@ -168,7 +170,9 @@ function plot_binary_discrimination_calibration_curves!(subfig::FigurePosition,
     set_from_kw!(calibration, :marker, kw, :rect)
     set_from_kw!(calibration, :linewidth, kw, 2)
 
-    Makie.series!(ax, calibration_curve; calibration...)
+    Makie.series!(ax, calibration_curve;
+                title="Detection calibration", xlabel="Expert agreement rate",
+                ylabel="Predicted positive probability", calibration...)
 
     ideal_theme = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :Ideal; color=(:black, 0.5),
                             linestyle=:dash)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -150,8 +150,7 @@ function plot_binary_discrimination_calibration_curves!(subfig::FigurePosition,
                                                         discrimination_class::AbstractString;
                                                         kw...)
     kw = values(kw)
-    scatter_theme = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :Scatter;
-                              strokewidth=0)
+    scatter_theme = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :Scatter; strokewidth=0)
     # Hayaah, this theme merging is getting out of hand
     # but we want kw > BinaryDiscriminationCalibrationCurves > Scatter, so we need to somehow set things
     # after the theme merging above, especially, since we also pass those to series!,
@@ -173,8 +172,7 @@ function plot_binary_discrimination_calibration_curves!(subfig::FigurePosition,
                           per_expert...)
     end
 
-    calibration = get_theme(subfig, :BinaryDiscriminationCalibrationCurves,
-                            :CalibrationCurve;
+    calibration = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :CalibrationCurve;
                             solid_color=:navyblue, markerstrokewidth=0)
 
     set_from_kw!(calibration, :markersize, kw, 5)
@@ -183,8 +181,7 @@ function plot_binary_discrimination_calibration_curves!(subfig::FigurePosition,
 
     Makie.series!(ax, calibration_curve; calibration...)
 
-    ideal_theme = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :Ideal;
-                            color=(:black, 0.5),
+    ideal_theme = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :Ideal; color=(:black, 0.5),
                             linestyle=:dash)
     set_from_kw!(ideal_theme, :linewidth, kw, 2)
     linesegments!(ax, [0, 1], [0, 1]; label="Ideal", ideal_theme...)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -141,12 +141,17 @@ function set_from_kw!(theme, key, kw, default)
 end
 
 function plot_binary_discrimination_calibration_curves!(subfig::FigurePosition,
-                                                        calibration_curve::SeriesCurves, calibration_score,
-                                                        per_expert_calibration_curves::Union{SeriesCurves,Missing},
-                                                        per_expert_calibration_scores, optimal_threshold,
-                                                        discrimination_class::AbstractString; kw...)
+                                                        calibration_curve::SeriesCurves,
+                                                        calibration_score,
+                                                        per_expert_calibration_curves::Union{SeriesCurves,
+                                                                                             Missing},
+                                                        per_expert_calibration_scores,
+                                                        optimal_threshold,
+                                                        discrimination_class::AbstractString;
+                                                        kw...)
     kw = values(kw)
-    scatter_theme = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :Scatter; strokewidth=0)
+    scatter_theme = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :Scatter;
+                              strokewidth=0)
     # Hayaah, this theme merging is getting out of hand
     # but we want kw > BinaryDiscriminationCalibrationCurves > Scatter, so we need to somehow set things
     # after the theme merging above, especially, since we also pass those to series!,
@@ -155,26 +160,31 @@ function plot_binary_discrimination_calibration_curves!(subfig::FigurePosition,
     set_from_kw!(scatter_theme, :marker, kw, :rect)
 
     if ismissing(per_expert_calibration_curves)
-        ax = Axis(subfig)
+        ax = Axis(subfig; title="Detection calibration", xlabel="Expert agreement rate",
+                  ylabel="Predicted positive probability", legend=nothing)
     else
-        per_expert = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :PerExpert; solid_color=:darkgrey,
-                            color=nothing)
+        per_expert = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :PerExpert;
+                               solid_color=:darkgrey,
+                               color=nothing)
         set_from_kw!(per_expert, :linewidth, kw, 2)
-        ax = series_plot!(subfig, per_expert_calibration_curves, nothing;  scatter=scatter_theme, per_expert...)
+        ax = series_plot!(subfig, per_expert_calibration_curves, nothing; legend=nothing,
+                          title="Detection calibration", xlabel="Expert agreement rate",
+                          ylabel="Predicted positive probability", scatter=scatter_theme,
+                          per_expert...)
     end
 
-    calibration = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :CalibrationCurve;
+    calibration = get_theme(subfig, :BinaryDiscriminationCalibrationCurves,
+                            :CalibrationCurve;
                             solid_color=:navyblue, markerstrokewidth=0)
 
     set_from_kw!(calibration, :markersize, kw, 5)
     set_from_kw!(calibration, :marker, kw, :rect)
     set_from_kw!(calibration, :linewidth, kw, 2)
 
-    Makie.series!(ax, calibration_curve;
-                title="Detection calibration", xlabel="Expert agreement rate",
-                ylabel="Predicted positive probability", calibration...)
+    Makie.series!(ax, calibration_curve; calibration...)
 
-    ideal_theme = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :Ideal; color=(:black, 0.5),
+    ideal_theme = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :Ideal;
+                            color=(:black, 0.5),
                             linestyle=:dash)
     set_from_kw!(ideal_theme, :linewidth, kw, 2)
     linesegments!(ax, [0, 1], [0, 1]; label="Ideal", ideal_theme...)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -160,7 +160,7 @@ function plot_binary_discrimination_calibration_curves!(subfig::FigurePosition,
 
     if ismissing(per_expert_calibration_curves)
         ax = Axis(subfig; title="Detection calibration", xlabel="Expert agreement rate",
-                  ylabel="Predicted positive probability", legend=nothing)
+                  ylabel="Predicted positive probability")
     else
         per_expert = get_theme(subfig, :BinaryDiscriminationCalibrationCurves, :PerExpert;
                                solid_color=:darkgrey,

--- a/test/learn.jl
+++ b/test/learn.jl
@@ -296,6 +296,11 @@ end
         @test !isequal(thresh_from_roc, thresh_from_calibration)
         @test isequal(thresh_from_calibration, plot_data_2["optimal_threshold"])
 
+        # Test binary discrimination with no multiclass votes
+        plot_data_1["per_expert_discrimination_calibration_curves"] = missing
+        no_expert_calibration = evaluation_metrics_plot(EvaluationRow(plot_data_1))
+        @testplot no_expert_calibration
+
         # Test that plotting succeeds (no specialization relative to the multi-class tests)
         plot_data = last(logger.logged["validation_set_evaluation/metrics_per_epoch"])
         all_together = evaluation_metrics_plot(plot_data)

--- a/test/learn.jl
+++ b/test/learn.jl
@@ -306,6 +306,23 @@ end
         all_together = evaluation_metrics_plot(plot_data)
         #savefig(all_together, "/tmp/binary.png")
         @testplot all_together
+
+        # Also, let's make sure we get an isolated discrimination plots
+        discrimination_cal = Lighthouse.plot_binary_discrimination_calibration_curves(plot_data_1["discrimination_calibration_curve"],
+                                                                                      plot_data_1["discrimination_calibration_score"],
+                                                                                      plot_data_1["per_expert_discrimination_calibration_curves"],
+                                                                                      plot_data_1["per_expert_discrimination_calibration_scores"],
+                                                                                      plot_data_1["optimal_threshold"],
+                                                                                      plot_data_1["class_labels"][plot_data_1["optimal_threshold_class"]])
+        @testplot discrimination_cal
+
+        discrimination_cal_no_experts = Lighthouse.plot_binary_discrimination_calibration_curves(plot_data_1["discrimination_calibration_curve"],
+                                                                                                 plot_data_1["discrimination_calibration_score"],
+                                                                                                 missing,
+                                                                                                 missing,
+                                                                                                 plot_data_1["optimal_threshold"],
+                                                                                                 plot_data_1["class_labels"][plot_data_1["optimal_threshold_class"]])
+        @testplot discrimination_cal_no_experts
     end
 end
 

--- a/test/learn.jl
+++ b/test/learn.jl
@@ -296,17 +296,6 @@ end
         @test !isequal(thresh_from_roc, thresh_from_calibration)
         @test isequal(thresh_from_calibration, plot_data_2["optimal_threshold"])
 
-        # Test binary discrimination with no multiclass votes
-        plot_data_1["per_expert_discrimination_calibration_curves"] = missing
-        no_expert_calibration = evaluation_metrics_plot(EvaluationRow(plot_data_1))
-        @testplot no_expert_calibration
-
-        # Test that plotting succeeds (no specialization relative to the multi-class tests)
-        plot_data = last(logger.logged["validation_set_evaluation/metrics_per_epoch"])
-        all_together = evaluation_metrics_plot(plot_data)
-        #savefig(all_together, "/tmp/binary.png")
-        @testplot all_together
-
         # Also, let's make sure we get an isolated discrimination plots
         discrimination_cal = Lighthouse.plot_binary_discrimination_calibration_curves(plot_data_1["discrimination_calibration_curve"],
                                                                                       plot_data_1["discrimination_calibration_score"],
@@ -322,6 +311,18 @@ end
                                                                                                  missing,
                                                                                                  plot_data_1["optimal_threshold"],
                                                                                                  plot_data_1["class_labels"][plot_data_1["optimal_threshold_class"]])
+
+        # Test binary discrimination with no multiclass votes
+        plot_data_1["per_expert_discrimination_calibration_curves"] = missing
+        no_expert_calibration = evaluation_metrics_plot(EvaluationRow(plot_data_1))
+        @testplot no_expert_calibration
+
+        # Test that plotting succeeds (no specialization relative to the multi-class tests)
+        plot_data = last(logger.logged["validation_set_evaluation/metrics_per_epoch"])
+        all_together = evaluation_metrics_plot(plot_data)
+        #savefig(all_together, "/tmp/binary.png")
+        @testplot all_together
+
         @testplot discrimination_cal_no_experts
     end
 end


### PR DESCRIPTION
...as encountered in internal Beacon project. 