### PR TITLE
work around Arrow issue with unions of Missing and non-concrete types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lighthouse"
 uuid = "ac2c24cd-07f0-4848-96b2-1b82c3ea0e59"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.0"
+version = "0.15.1"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/src/row.jl
+++ b/src/row.jl
@@ -10,13 +10,19 @@ function vec_to_mat(vec::AbstractVector)
     n = isqrt(length(vec))
     return reshape(vec, n, n)
 end
-vec_to_mat(x::Missing) = return missing
+vec_to_mat(::Missing) = missing
 
 const GenericCurve = Tuple{Vector{Float64},Vector{Float64}}
 @schema "lighthouse.evaluation" Evaluation
 @version EvaluationV1 begin
     class_labels::Union{Missing,Vector{String}}
-    confusion_matrix::Union{Missing,Array{Int64}} = vec_to_mat(confusion_matrix)
+    # XXX why do we spell out the different array types?
+    # For Arrow, we need to be able to serialize as a vector
+    # but we also want to be able to store a matrix directly.
+    # Then why not just use Array{Int64? Because that's an
+    # abstract type, which creates serialization issues in
+    # unions with Missing.
+    confusion_matrix::Union{Missing,Array{Int64,1},Array{Int64,2}} = vec_to_mat(confusion_matrix)
     discrimination_calibration_curve::Union{Missing,GenericCurve}
     discrimination_calibration_score::Union{Missing,Float64}
     multiclass_IRA_kappas::Union{Missing,Float64}
@@ -47,7 +53,7 @@ end
 """
     @version EvaluationV1 begin
         class_labels::Union{Missing,Vector{String}}
-        confusion_matrix::Union{Missing,Array{Int64}} = vec_to_mat(confusion_matrix)
+        confusion_matrix::Union{Missing,Array{Int64,1},Array{Int64,2}} = vec_to_mat(confusion_matrix)
         discrimination_calibration_curve::Union{Missing,GenericCurve}
         discrimination_calibration_score::Union{Missing,Float64}
         multiclass_IRA_kappas::Union{Missing,Float64}
@@ -269,7 +275,7 @@ LabelMetricsV1
 
 @schema "lighthouse.hardened-metrics" HardenedMetrics
 @version HardenedMetricsV1 > ClassV1 begin
-    confusion_matrix::Union{Missing,Array{Int64}} = vec_to_mat(confusion_matrix)
+    confusion_matrix::Union{Missing,Array{Int64,1},Array{Int64,2}} = vec_to_mat(confusion_matrix)
     discrimination_calibration_curve::Union{Missing,Curve} = lift(Curve,
                                                                   discrimination_calibration_curve)
     discrimination_calibration_score::Union{Missing,Float64}
@@ -278,7 +284,7 @@ end
 
 """
     @version HardenedMetricsV1 > ClassV1 begin
-        confusion_matrix::Union{Missing,Array{Int64}} = vec_to_mat(confusion_matrix)
+        confusion_matrix::Union{Missing,Array{Int64,1},Array{Int64,2}} = vec_to_mat(confusion_matrix)
         discrimination_calibration_curve::Union{Missing,Curve} = lift(Curve,
                                                                       discrimination_calibration_curve)
         discrimination_calibration_score::Union{Missing,Float64}

--- a/src/row.jl
+++ b/src/row.jl
@@ -19,7 +19,7 @@ const GenericCurve = Tuple{Vector{Float64},Vector{Float64}}
     # XXX why do we spell out the different array types?
     # For Arrow, we need to be able to serialize as a vector
     # but we also want to be able to store a matrix directly.
-    # Then why not just use Array{Int64? Because that's an
+    # Then why not just use Array{Int64}? Because that's an
     # abstract type, which creates serialization issues in
     # unions with Missing.
     confusion_matrix::Union{Missing,Array{Int64,1},Array{Int64,2}} = vec_to_mat(confusion_matrix)


### PR DESCRIPTION
This could technically be seen as a breaking change to the schema, because a user could have passed a 3+ dimensional array previously. I wouldn't count it as breaking (and instead view it as a bugfix) because it was always supposed to be a container for a confusion matrix, but I'll let others cast their votes.