### PR TITLE
work around Arrow issue with unions of Missing and non-concrete types

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-*
     tags:
       - v*
   pull_request:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lighthouse"
 uuid = "ac2c24cd-07f0-4848-96b2-1b82c3ea0e59"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.14.16"
+version = "0.14.18"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/src/row.jl
+++ b/src/row.jl
@@ -20,7 +20,7 @@ const EVALUATION_ROW_SCHEMA = Legolas.Schema("lighthouse.evaluation@1")
 """
     const EvaluationRow = Legolas.@row("lighthouse.evaluation@1",
                                    class_labels::Union{Missing,Vector{String}},
-                                   confusion_matrix::Union{Missing,Array{Int64}} = vec_to_mat(confusion_matrix),
+                                   confusion_matrix::Union{Missing,Array{Int64,1},Array{Int64,2}} = vec_to_mat(confusion_matrix),
                                    discrimination_calibration_curve::Union{Missing,
                                                                            Tuple{Vector{Float64},
                                                                                  Vector{Float64}}},
@@ -75,7 +75,13 @@ Constructor that takes `evaluation_row_dict` converts [`evaluation_metrics`](@re
 """
 const EvaluationRow = Legolas.@row("lighthouse.evaluation@1",
                                    class_labels::Union{Missing,Vector{String}},
-                                   confusion_matrix::Union{Missing,Array{Int64}} = vec_to_mat(confusion_matrix),
+                                    # XXX why do we spell out the different array types?
+                                    # For Arrow, we need to be able to serialize as a vector
+                                    # but we also want to be able to store a matrix directly.
+                                    # Then why not just use Array{Int64}? Because that's an
+                                    # abstract type, which creates serialization issues in
+                                    # unions with Missing.
+                                   confusion_matrix::Union{Missing,Array{Int64,1},Array{Int64,2}} = vec_to_mat(confusion_matrix),
                                    discrimination_calibration_curve::Union{Missing,
                                                                            Tuple{Vector{Float64},
                                                                                  Vector{Float64}}},
@@ -298,7 +304,7 @@ const LabelMetricsRow = Legolas.@row("lighthouse.label-metrics@1" > "lighthouse.
 """
     HardenedMetricsRow = Legolas.@row("lighthouse.hardened-metrics@1" >
                                         "lighthouse.class@1",
-                                        confusion_matrix::Union{Missing,Array{Int64}} = vec_to_mat(confusion_matrix),
+                                        confusion_matrix::Union{Missing,Array{Int64,1},Array{Int64,2}} = vec_to_mat(confusion_matrix),
                                         discrimination_calibration_curve::Union{Missing,Curve} = ismissing(discrimination_calibration_curve) ?
                                                                                                  missing :
                                                                                                  Curve(discrimination_calibration_curve),
@@ -312,7 +318,7 @@ and [`get_hardened_metrics_multiclass`](@ref).
 """
 const HardenedMetricsRow = Legolas.@row("lighthouse.hardened-metrics@1" >
                                         "lighthouse.class@1",
-                                        confusion_matrix::Union{Missing,Array{Int64}} = vec_to_mat(confusion_matrix),
+                                        confusion_matrix::Union{Missing,Array{Int64,1},Array{Int64,2}} = vec_to_mat(confusion_matrix),
                                         discrimination_calibration_curve::Union{Missing,Curve} = ismissing(discrimination_calibration_curve) ?
                                                                                                  missing :
                                                                                                  Curve(discrimination_calibration_curve),


### PR DESCRIPTION
* work around Arrow issue with unions of Missing and non-concrete types (#102)

* patch bump

(cherry picked from commit 4e1371d3584d8e0976ac559ed86bacee1141a7ac)