### PR TITLE
zizmor audit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,8 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - Makie v${{ matrix.makie }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -31,11 +33,13 @@ jobs:
             version: 'min'
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3
         with:
           cache-compiled: true
           cache-name: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ matrix.makie }}
@@ -45,15 +49,15 @@ jobs:
           using Pkg
           Pkg.instantiate()
           Pkg.add(Pkg.PackageSpec(; name="Makie", version="${{ matrix.makie }}"))
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-runtest@d60b785c6f2bdf4ebfb18b2b6f7d93b7dfb0efe3 # v1
       - name: Percy Upload
-        uses: percy/exec-action@v0.3.1
+        uses: percy/exec-action@20e02fc241611bb7842e20e94076217c1d7663fd # v0.3.1
         if: ${{ matrix.version == 1 && matrix.makie == 0.24 }}
         with:
           custom-command: "npx @percy/cli upload ./test/plot_results"
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-      - uses: julia-actions/julia-processcoverage@v1
+      - uses: julia-actions/julia-processcoverage@03114f09f119417c3242a9fb6e0b722676aedf38 # v1
       - uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
         with:
           files: lcov.info
@@ -61,16 +65,21 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      statuses: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: '1.10'
-      - uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3
         with:
            cache-compiled: true
            cache-name: ${{ github.workflow }}-${{ github.job }}
-      - uses: julia-actions/julia-docdeploy@v1
+      - uses: julia-actions/julia-docdeploy@e62cc8fd639797a0c2922a437d5b1b81c4a12787 # v1
         env:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # when run by tagbot
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -8,8 +8,11 @@ jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/clean_up_pr_previews.yml
+++ b/.github/workflows/clean_up_pr_previews.yml
@@ -7,11 +7,14 @@ on:
 jobs:
   doc-preview-cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: gh-pages
+          persist-credentials: false
       - name: Delete preview and history + push changes
         run: |
             if [ -d "previews/PR$PRNUM" ]; then

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
       - 'main'
-    tags: '*'
+    tags:
+      - '*'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     # note: keep in sync with `format/run.jl`
@@ -18,19 +19,24 @@ jobs:
     # Run on push's or non-draft PRs
     if: (github.event_name == 'push') || (github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         julia-version: [1.8]
     steps:
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: ${{ matrix.julia-version }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Instantiate `format` environment and format
         run: |
           julia --project=format -e 'using Pkg; Pkg.instantiate()'
           julia --project=format 'format/run.jl'
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         if: github.event_name == 'pull_request'
         with:
           tool_name: JuliaFormatter

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,28 @@
+---
+name: GitHub Actions Security Analysis with zizmor 🌈
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+permissions: {}
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      # security-events: write  # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read  # Only needed for private repos. Needed to clone the repo.
+      # actions: read  # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e  # v0.5.3
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
## Permissions Changes

| Workflow | Job | Permissions Before | Permissions After | Rationale |
|---|---|---|---|---|
| CI.yml | `test` | default (broad) | `contents: read` | Read-only: checkout + run tests; Codecov uses a secret token |
| CI.yml | `docs` | default (broad) | `contents: write`, `statuses: write` | Documenter.jl pushes to gh-pages and posts commit status |
| CompatHelper.yml | `CompatHelper` | default (broad) | `contents: write`, `pull-requests: write` | Creates branches and opens PRs for compat updates |
| TagBot.yml | `TagBot` | default (broad) | `contents: write`, `issues: read` | Creates git tags/releases; `issues: read` for `issue_comment` trigger |
| clean_up_pr_previews.yml | `doc-preview-cleanup` | default (broad) | `contents: write` | Force-pushes cleaned gh-pages branch |
| format.yml | `format-check` | default (broad) | `contents: read`, `pull-requests: write` | Reads code; reviewdog posts inline PR suggestions |
| zizmor.yaml | `zizmor` | — (new file) | `contents: read` | Clones repo to run audit |
